### PR TITLE
PropertyData is deprecated, replace with MemberData

### DIFF
--- a/CheatSheets/XUnitCheatSheet.cs
+++ b/CheatSheets/XUnitCheatSheet.cs
@@ -63,7 +63,7 @@ namespace GenericsExamples.Tests
         /// <param name="number">Test data</param>
         /// <param name="expectedResult">Expected Result</param>
         [Theory]
-        [PropertyData("SamplePropertyDataProperty")]
+        [MemberData(nameof(SamplePropertyDataProperty))]
         public void PropertyDataExample(int number, bool expectedResult)
         {
             Console.WriteLine("AccountTests.PropertyDataExample(int {0}, bool {1})", number, expectedResult);


### PR DESCRIPTION
Ran into this when looking into examples of parametrizing xunit-test and noticed that the example with PropertyData is using a deprecated api which is replaced with MemberData.

Adding a PR so more people can take advantage of my findings. 